### PR TITLE
prompt interface for the wrapper

### DIFF
--- a/src/app/api_endpoint.py
+++ b/src/app/api_endpoint.py
@@ -1,0 +1,49 @@
+# app/main.py
+from fastapi import FastAPI, HTTPException
+from .models import CommandRequest, CommandResponse
+from .llm_wrapper import LLMWrapper
+import logging
+
+app = FastAPI(title="LLM Wrapper Command API")
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+modeltyp = "text-generation"
+model="TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+
+# Instantiate the LLMWrapper
+wrapper = LLMWrapper(modeltyp=None, model = None)
+
+
+@app.post("/command", response_model=CommandResponse)
+async def handle_command(command_request: CommandRequest):
+    command = command_request.command.lower()
+    params = command_request.params or {}
+
+    try:
+        if command == "deploy":
+            wrapper.llm._modeltyp = params.get("model_type")
+            wrapper.llm.model = params.get("model_name")
+            if not wrapper.llm.model_type or not wrapper.llm.model_name:
+                raise ValueError("Parameters 'model_type' and 'model_name' are required for deploy command.")
+            wrapper.llm.download_model()
+            return CommandResponse(status="success", detail="LLM deployed successfully.")
+        
+        elif command == "shutdown":
+            wrapper.llm.shutdown()
+            return CommandResponse(status="success", detail="LLM shutdown successfully.")
+        
+        elif command == "status":
+            logger.info("Launch command status")
+            status_info = wrapper.llm.get_status()
+            logger.info(f"status info = {status_info}")
+            return CommandResponse(status="success", data=status_info)
+        
+    except Exception as e:
+        logger.error(f"Error handling command '{command}': {e}")
+        raise HTTPException(
+            status_code=400,
+            detail=str(e),
+        )

--- a/src/app/llm_model.py
+++ b/src/app/llm_model.py
@@ -1,15 +1,23 @@
-# pragma: no cover
+import gc
 import logging
+import psutil  # for memory monitoring
+
 import torch
+import asyncio
 from transformers import pipeline
 
-# pragma: no cover
 logging.basicConfig(
-    filename="llm.log",  
-    filemode="w",        
+    filename="llm.log",
+    filemode="w",
     level=logging.DEBUG,
-    format="%(asctime)s - %(levelname)s - %(message)s"
+    format="%(asctime)s - %(levelname)s - %(message)s",
 )
+
+class RestartError(Exception):
+    def __init__(self, message, errors):
+        super().__init__(message)
+        self.errors = errors
+
 
 class LLMModel:
     def __init__(self, modeltyp, model):
@@ -19,70 +27,206 @@ class LLMModel:
         self._message = None
         self._answer = None
         self._prompt = None
+        self._status = "idle"
+        self._process = psutil.Process()
+        self._init_memory_usage = self._process.memory_info().rss
 
-    
-   
-    def download_model(self):
+    _status_codes = {
+        "not ready": " LLM Wrapper is not able to process prompts",
+        "failure": "LLM Wrapper cannot deploy an LLM, or the deployed LLM is unable to process prompts despite repair attempts",
+        "idle": "LLM Wrapper has no deployed LLM and is waiting for a new deployment",
+        "ready": "LLM Wrapper has an LLM deployed and is ready to process prompts",
+        "prompting": "LLM Wrapper is currently in use by the Prompting Service",
+        "deploying": "LLM is currently being deployed to the Wrapper",
+        "stopping": "LLM Wrapper is in the process of stopping its current LLM",
+        "shutdown": "LLM Wrapper is being shut down",
+    }
+
+
+
+    def download_model(self, attempt=0):
         """
         downloads a model from huggingface via the api with self.modeltyp and self.model
         """
         try:
-            self._pipe = pipeline(self.modeltyp, model= self.model, torch_dtype=torch.bfloat16, device_map="auto")
-            logging.info("Successfully downloaded the desired model")
+            self._pipe = pipeline(
+                self.modeltyp,
+                model=self.model,
+                torch_dtype=torch.bfloat16,
+                device_map="auto",
+            )
+            if self._isresponsive():
+                self._status = "ready"
+                logging.info(f"{self._status_codes[self.status]}, model = {self.model}")
+            else:
+                logging.info(
+                    f"downloaded llm is unresposive try to restart attempt = {attempt + 1}"
+                )
+                if attempt <= 3:
+                    self.restart(attempt=attempt + 1)
         except Exception as e:
-            logging.error(f"Failed to download the LLM-Model {self.model} because of following Exception: {e}")
+            self._status = "failure"
+            logging.error(
+                f"Failed to download the LLM-Model {self.model} because of following Exception: {e}"
+            )
+            logging.error(f"{self._status_codes[self._status]}, model = {self.model}")
+
+
+    def get_status(self):
+        return {
+            "status": self.status,
+            "deployed_llm": self.model,
+        }
+
+    def shutdown(self):
+        """
+        discards the llm and sets the wrapper to the same state as after initialization
+        """
+        if self.status == "idle":
+            logging.info("Shutdown canceled: Wrapper is already idle.")
+            return
+
+        try:
+            self._status = "stopping"
+            del self._pipe
+            gc.collect()
+            self._pipe = None
             
+            if (self._init_memory_usage * 1.2) < self._process.memory_info().rss: # current resource usage is greater than init usage + 20% than the shutdown wasn't succesfull
+                
+                logging.error(f"“Error when shutting down the llm {self.model}: shutdown wasn't succesfull") 
+                self._status = "failure" 
+            else:
+                self._message = None
+                self._answer = None
+                self._prompt = None
+                self._status = "idle"
+                logging.info("shutdown llm")
+                logging.info(f"Status: {self.status} - {self._status_codes[self.status]}")
+        except Exception as e:
+            logging.error(f"“Error when shutting down the llm: {e}")
+            self._status = "failure"
+
+
+
+    def restart(self, attempt=0):
+        """
+        Restarts the llm. If unable to restart the llm for instance the llm is unresponsive it will start another attempt.
+
+        Args:
+            attempt (int): number of attempt to restart the llm. Default is 0. If attempt >= 3 will set the Wrapper status to failure
+        """
+        if attempt >= 3:
+            self._status = "failure"
+            logging.error(f"failed to restart the llm number of attempts = {attempt}")
+            logging.error(
+                f"Status: {self.status} - {self._status_codes[self.status]}, model = {self.model}"
+            )
+            return
+        
+        if self.status == "idle":
+            logging.info("Restart not possible, because no LLM is running.")
+            return
+
+        try:
+            logging.info(f"Restarting the llm (attempt {attempt + 1}).")
+            self.shutdown()
+            self._status = "not ready"
+            self.download_model(attempt=attempt)
+        except Exception as e:
+            logging.error(f"Error when restarting the llm {self.model}, excepion: {e}")
+            logging.error(f"Attempt {attempt + 1} failed. New attempt...")
+            self.restart(attempt=attempt + 1)
+
 
 
     def answer_question(self, question):
         """
         generates an answer to the given question with the downloaded LLM
 
-        Args: 
+        Args:
             question (str): The question that should be answered by the llm.
 
-        Retruns:
-            string: The answer 
+        Returns:
+            string: The answer
             or None: if no llm has been downloaded
         """
         logging.debug(question)
-        
+
         if self._pipe is None:
             logging.info("No LLM in pipe")
             return
-        
+
         self._message = [
             {"role": "user", "content": question},
         ]
 
         logging.info(f"new message forwarded to the llm - {self.message}")
-        
-        self._prompt = self._pipe.tokenizer.apply_chat_template(self.message, tokenize=False, add_generation_prompt=True)
-        output = self._pipe(self._prompt, max_new_tokens=256, do_sample=True, temperature=0.7, top_k=50, top_p=0.95)
+
+        self._prompt = self._pipe.tokenizer.apply_chat_template(
+            self.message, tokenize=False, add_generation_prompt=True
+        )
+        output = self._pipe(
+            self._prompt,
+            max_new_tokens=256,
+            do_sample=True,
+            temperature=0.7,
+            top_k=50,
+            top_p=0.95,
+        )
         parts = output[0]["generated_text"].split("<|assistant|>\n")
         if len(parts) > 1:
             self._answer = parts[1]
         else:
             self._answer = output[0]["generated_text"]
-        
+
         return self.answer
-    
+
+
+
+    def _isresponsive(self):
+        """
+        Checks if the model can respond to queries.
+        sends a prompt to the downloaded llm and returns true if the llm is returning an answer otherwise returns false
+
+        Returns:
+            bool: true if the llm can send answer questions otherwise false
+        """
+        example = "What's the capitol of germany?"
+        logging.info("Überprüfung der Modellantwort mit Testfrage gestartet.")
+        
+        try:
+            llmresponse = self.answer_question(example)
+        
+            if llmresponse is None:
+                logging.warning(f"The model {self.model} did not provide any response.")
+                return False
+            if isinstance(llmresponse, str):
+                logging.info(f"The model {self.model} successfully responded: {llmresponse}")
+                return True
+        
+            logging.error(f"Unexpected response type from the model {self.model}: {type(llmresponse)}")
+            return False
+        except Exception as e:
+            logging.error(f"Error during model responsiveness check: {e}")
+            return False
 
     @property
     def modeltyp(self):
         return self._modeltyp
 
-        
     @property
     def model(self):
         return self._model
-    
-        
+
     @property
     def message(self):
         return self._message
-    
 
     @property
     def answer(self):
         return self._answer
+
+    @property
+    def status(self):
+        return self._status

--- a/src/app/llm_wrapper.py
+++ b/src/app/llm_wrapper.py
@@ -1,0 +1,110 @@
+import logging
+import asyncio
+from threading import Thread
+from .llm_model import LLMModel, RestartError
+import time
+
+logging.basicConfig(
+    filename="wrapper.log",
+    filemode="w",
+    level=logging.DEBUG,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+
+class LLMWrapper:
+
+    def __init__(self, modeltyp, model):
+        self._is_llm_healthy = True
+        self._monitoring_task = None
+        self.llm = LLMModel(modeltyp=modeltyp, model = model)
+        self._max_timeout = 120 # Abbruch während des periodischen Health checks wenn festgestellt wird, dass llm bereits seit mehr als 120 sekunden prompting
+        self._started_prompting = None
+        self._llm_restarting = False
+
+    async def _health_check_function(self):
+        """Die Funktion, die durch das Monitoring überprüft wird."""
+        try:
+            logging.info("performing health check")
+            if time.time() - self._started_prompting > self._max_timeout:
+                return False
+            if self.llm.status in ["idle", "ready", "stopping"] \
+                or self._started_prompting is None \
+                or (time.time() - self._started_prompting) <= self._max_timeout:
+                return True
+            return False
+        except Exception as e:
+            logging.error(f"Health-Check-Error: {e}")
+            return False
+
+    async def _monitor_health(self):
+        """Die Überwachungslogik, die alle 60 Sekunden ausgeführt wird."""
+        while True:
+            self._is_healthy = await self._health_check_function()
+            if self._is_healthy:
+                logging.info("the llm is healthy")
+            else:
+                logging.warning("the llm is unhealthy - try to restart")
+                self._llm_restarting = True
+                self.llm.restart()
+                while self._llm_restarting:
+                    if self.llm.status in ["ready", "prompting"]:
+                        self._llm_restarting = False
+                    elif self.llm.status == "failure":
+                        raise RestartError
+                    await asyncio.sleep(10) # Zeit bis zur Überprüfung ob der restart erforlgreich oder erfolglos war
+
+            await asyncio.sleep(60) # Zeit bis zum nächsten periodischen Health check
+
+    def start_monitoring(self):
+        """Startet das Health-Monitoring in einem separaten Thread."""
+        if self._monitoring_task is None:
+            loop = asyncio.new_event_loop()
+
+            def run_loop():
+                asyncio.set_event_loop(loop)
+                loop.run_until_complete(self._monitor_health())
+
+            self._monitoring_task = Thread(target=run_loop, daemon=True)
+            self._monitoring_task.start()
+
+    def stop_monitoring(self):
+        """Beendet das Health-Monitoring."""
+        if self._monitoring_task:
+            self._monitoring_task = None
+
+    def get_answer(self, question):
+        self._started_prompting = time.time()
+        logging.info("Task wird ausgeführt...")
+        answer = self.llm.answer_question(question)
+        logging.info(f"Answer: {answer} - Question: {question}")
+        self._started_prompting = None
+        return answer
+
+"""
+if __name__ == "__main__":
+    questions = ["Whats the capitol of France?",
+                 "How much does a litre of water weigh?",
+                 "Wie viele Cent ergeben einen Euro?",
+                 "Che cos'è 7 + 5 ?",
+                 "Was besagt das deutsche Reinheitsgebot?"]
+    
+    wrapper = LLMWrapper(modeltyp="text-generation", model = "TinyLlama/TinyLlama-1.1B-Chat-v1.0")
+    wrapper.start_monitoring()
+
+    wrapper.llm.download_model()
+
+    try:
+        for question in questions:
+            if wrapper.llm.status == "ready":
+                wrapper.get_answer(question)
+            else:
+                time.sleep(5)
+    except RestartError as re:
+        logging.error(f"LLM failed to restart {re}")
+    except Exception as e:
+        logging.error(f"wrapper failed for reasons unknown {e}")
+    finally:
+        wrapper.llm.shutdown()
+        wrapper.stop_monitoring()
+        
+"""

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel, Field
+from typing import Optional, Dict
+
+class CommandRequest(BaseModel):
+    command: str = Field(..., example="deploy")
+    params: Optional[Dict[str, str]] = Field(
+        None, example={"model_type": "text-generation", "model_name": "TinyLlama/TinyLlama-1.1B-Chat-v1.0"}
+    )
+
+class CommandResponse(BaseModel):
+    status: str
+    detail: Optional[str] = None
+    data: Optional[dict] = None


### PR DESCRIPTION
The /command endpoint is designed to manage the lifecycle of a Language Model (LLM) via commands such as deploying, shutting down, or checking the status of the model. The API is built using FastAPI and interacts with a wrapper for managing the LLM.

URL: /command
Method: POST
Request Body:

command (string, required): Specifies the action to perform. Possible values are:
 - "deploy": Deploys a new LLM model.
 - "shutdown": Shuts down the currently deployed model.
 - "status": Retrieves the current status of the wrapper and the LLM.
 
ISSUE :

The /deploy endpoint seems to be bugged at the moment, I encounter an issue when going on this endpoint because of a setter issue.


